### PR TITLE
Self-Termination

### DIFF
--- a/_posts/2018-11-03-actor-system-is-quarantined.md
+++ b/_posts/2018-11-03-actor-system-is-quarantined.md
@@ -35,7 +35,7 @@ public class Terminator : ReceiveActor
 {
     public Terminator()
     {
-        Receive<QuarantinedEvent>(m => 
+        Receive<ThisActorSystemQuarantinedEvent>(m => 
         {
             Actors.Instance.Shutdown();
         });
@@ -43,7 +43,7 @@ public class Terminator : ReceiveActor
 }
 {% endhighlight %}
 
-Terminator in my case is a simple Actor ready to receive `QuarantinedEvent` messages delivered to my unhealthy cluster node.
+Terminator in my case is a simple Actor ready to receive `ThisActorSystemQuarantinedEvent` messages delivered to my unhealthy cluster node.
 
 Here I'm using a small wrapper around the ActorSystem called `Actors`. This object gives me some control around the actor system lifecycle and I use it to invoke the `CoordinatedShutdown` method as recommended by the Akka.net team.
 
@@ -53,7 +53,7 @@ Let's add the following to our actor system setup.
 
 {% highlight csharp %}
 var arnold = system.ActorOf(Props.Create<Terminator>());
-system.EventStream.Subscribe(arnold, typeof(QuarantinedEvent));
+system.EventStream.Subscribe(arnold, typeof(ThisActorSystemQuarantinedEvent));
 {% endhighlight %}
 
 And that's all that's needed.


### PR DESCRIPTION
QuarantinedEvent is emitting if the local system quarantined a remote node
ThisActorSystemQuarantinedEvent is emitting when a reconnection failed because the remote system already quarantined the local node.

The BAD effect of using QuarantinedEvent is that the whole cluster would restart (excl. the quarantined node) 
so that the quarantined node can reconnect to the restarted cluster...
